### PR TITLE
Fixed typo on feature section (ever to every)

### DIFF
--- a/src/includes/home/features.njk
+++ b/src/includes/home/features.njk
@@ -37,7 +37,7 @@
     {{ single_feature(
         "🔎",
         "Community Directory",
-        "Search and find people or groups across ever channel you’ve integrated."
+        "Search and find people or groups across every channel you’ve integrated."
         )
     }}
     {{ single_feature(


### PR DESCRIPTION
Before: 'Search and find people or groups across **ever** channel you’ve integrated.'

After: 'Search and find people or groups across **every** channel you’ve integrated.'