### PR TITLE
add Tanay Pant's n8n Orbit node to community built card

### DIFF
--- a/src/includes/developers/offerings.njk
+++ b/src/includes/developers/offerings.njk
@@ -135,6 +135,11 @@
               title: "DEV to Orbit Ruby Gem",
               link: "https://github.com/bencgreenberg/dev_orbit",
               description: "Integrate DEV Community interactions into your Orbit workspace in Ruby by <a href='https://twitter.com/rabbigreenberg' class='underline'>Ben Greenberg</a>"
+            },
+            {
+              title: "n8n Node for Orbit",
+              link: "https://docs.n8n.io/nodes/n8n-nodes-base.orbit/",
+              description: "Build Orbit workflows on n8n using the Orbit node by <a href='https://twitter.com/tanay1337' class='underline'>Tanay Pant</a>"
             }            
           ]
         }


### PR DESCRIPTION
It was in the earlier draft for the developer's landing page, but accidentally got dropped when it was refactored into reusable components.